### PR TITLE
Add rhythm mini-game, mobile touch controls, and UI improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,19 @@
                             <button class="btn btn-primary play-btn" data-game="snake">지금 플레이</button>
                         </div>
                     </div>
+                    <div class="project-card glass">
+                        <div class="project-img rhythm-preview">
+                        </div>
+                        <div class="project-info">
+                            <h3>클릭 리듬 챌린지</h3>
+                            <p>비트 타이밍에 맞춰 터치/클릭해서 콤보를 쌓으세요.</p>
+                            <div class="project-tags">
+                                <span>리듬</span>
+                                <span>반응속도</span>
+                            </div>
+                            <button class="btn btn-primary play-btn" data-game="rhythm">지금 플레이</button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </section>
@@ -136,6 +149,13 @@
                         <p id="game-instr">방향키 또는 터치로 이동하세요.</p>
                         <button id="start-btn" class="btn btn-primary">시작</button>
                     </div>
+                </div>
+                <div id="mobile-controls" class="mobile-controls">
+                    <button class="control-btn" data-control="left" aria-label="왼쪽으로 이동">◀</button>
+                    <button class="control-btn" data-control="up" aria-label="위로 이동">▲</button>
+                    <button class="control-btn" data-control="action" aria-label="액션">TAP</button>
+                    <button class="control-btn" data-control="down" aria-label="아래로 이동">▼</button>
+                    <button class="control-btn" data-control="right" aria-label="오른쪽으로 이동">▶</button>
                 </div>
             </div>
         </div>

--- a/main.js
+++ b/main.js
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Mobile Controls
     const mobileControls = document.getElementById('mobile-controls');
     const controlButtons = document.querySelectorAll('.control-btn');
-    const isTouchDevice = window.matchMedia('(max-width: 1024px) and (pointer: coarse)').matches;
+    const touchQuery = window.matchMedia('(pointer: coarse)');
 
     const setTheme = (theme) => {
         document.documentElement.setAttribute('data-theme', theme);
@@ -180,10 +180,14 @@ document.addEventListener('DOMContentLoaded', () => {
     let combo = 0;
     let bestCombo = 0;
 
+    function shouldShowTouchControls() {
+        return Boolean(currentGame) && gameActive && modal.style.display === 'block' && touchQuery.matches;
+    }
+
     function updateMobileControlsVisibility() {
         if (!mobileControls) return;
 
-        const shouldShowControls = Boolean(currentGame) && isTouchDevice;
+        const shouldShowControls = shouldShowTouchControls();
         mobileControls.style.display = shouldShowControls ? 'grid' : 'none';
 
         const visibleControlsByGame = {
@@ -348,6 +352,10 @@ document.addEventListener('DOMContentLoaded', () => {
         keys[e.code] = false;
     });
 
+    gameCanvas.addEventListener('touchmove', e => {
+        if (currentGame) e.preventDefault();
+    }, { passive: false });
+
     gameCanvas.addEventListener('touchstart', e => {
         e.preventDefault();
         const touchX = e.touches[0].clientX;
@@ -384,6 +392,7 @@ document.addEventListener('DOMContentLoaded', () => {
         gameTitle.innerText = title;
         gameInstr.innerText = getGameText(currentGame).instr;
         overlay.style.display = 'flex';
+        updateMobileControlsVisibility();
 
         if (currentGame === 'galaxy-runner') {
             obstacles = [];
@@ -416,12 +425,14 @@ document.addEventListener('DOMContentLoaded', () => {
             rhythmLastMissCheckedBeat = -1;
             rhythmLastHitBeat = -1;
         }
+        updateMobileControlsVisibility();
         gameLoop();
     }
 
     function stopGame() {
         gameActive = false;
         cancelAnimationFrame(animationId);
+        updateMobileControlsVisibility();
     }
 
     function spawnObstacle() {
@@ -613,6 +624,7 @@ document.addEventListener('DOMContentLoaded', () => {
         gameTitle.innerText = '리듬 챌린지 종료';
         gameInstr.innerText = `점수: ${score} | 최고 콤보: ${bestCombo}`;
         overlay.style.display = 'flex';
+        updateMobileControlsVisibility();
     }
 
     function gameOver() {
@@ -620,6 +632,7 @@ document.addEventListener('DOMContentLoaded', () => {
         gameTitle.innerText = '게임 오버';
         gameInstr.innerText = `최종 점수: ${score}`;
         overlay.style.display = 'flex';
+        updateMobileControlsVisibility();
         setTimeout(() => {
             if (overlay.style.display === 'flex') {
                 const { title } = getGameText(currentGame);
@@ -641,6 +654,8 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         updateMobileControlsVisibility();
     });
+
+    touchQuery.addEventListener('change', updateMobileControlsVisibility);
 
     const observer = new IntersectionObserver((entries) => {
         entries.forEach(entry => {

--- a/main.js
+++ b/main.js
@@ -171,14 +171,19 @@ document.addEventListener('DOMContentLoaded', () => {
     let snakeSpeed = 10;
 
     // Rhythm Game State
-    const rhythmBeatInterval = 800;
-    const rhythmWindow = { perfect: 120, good: 220 };
-    const rhythmDuration = 30000;
+    const rhythmBeatInterval = 680;
+    const rhythmWindow = { perfect: 90, good: 170 };
+    const rhythmDuration = 45000;
     let rhythmStartTime = 0;
     let rhythmLastMissCheckedBeat = -1;
     let rhythmLastHitBeat = -1;
     let combo = 0;
     let bestCombo = 0;
+    let rhythmMultiplier = 1;
+    let rhythmAccuracy = { perfect: 0, good: 0, miss: 0 };
+    let rhythmJudgeText = '';
+    let rhythmJudgeColor = '#fff';
+    let rhythmJudgeTime = 0;
 
     function shouldShowTouchControls() {
         return Boolean(currentGame) && gameActive && modal.style.display === 'block' && touchQuery.matches;
@@ -223,7 +228,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function getGameText(type) {
         if (type === 'galaxy-runner') return { title: '불규칙한 똥 피하기', instr: '방향키/좌우 버튼으로 이동하세요.' };
         if (type === 'snake') return { title: '네온 스네이크', instr: '방향키/방향 버튼으로 뱀을 조종하세요.' };
-        return { title: '클릭 리듬 챌린지', instr: '비트가 원에 겹칠 때 클릭/스페이스/TAP!' };
+        return { title: '클릭 리듬 챌린지', instr: '원형 노트가 판정선에 닿을 때 클릭/스페이스/TAP!' };
     }
 
     playButtons.forEach(btn => {
@@ -273,15 +278,30 @@ document.addEventListener('DOMContentLoaded', () => {
         if (beat === rhythmLastHitBeat) return;
 
         if (diff <= rhythmWindow.perfect) {
-            score += 3;
+            rhythmJudgeText = 'PERFECT';
+            rhythmJudgeColor = '#22d3ee';
+            rhythmJudgeTime = now;
+            rhythmAccuracy.perfect++;
             combo += 1;
+            rhythmMultiplier = Math.min(4, 1 + Math.floor(combo / 8));
+            score += 4 * rhythmMultiplier;
             rhythmLastHitBeat = beat;
         } else if (diff <= rhythmWindow.good) {
-            score += 1;
+            rhythmJudgeText = 'GOOD';
+            rhythmJudgeColor = '#34d399';
+            rhythmJudgeTime = now;
+            rhythmAccuracy.good++;
             combo += 1;
+            rhythmMultiplier = Math.min(4, 1 + Math.floor(combo / 8));
+            score += 2 * rhythmMultiplier;
             rhythmLastHitBeat = beat;
         } else {
+            rhythmJudgeText = 'MISS';
+            rhythmJudgeColor = '#fb7185';
+            rhythmJudgeTime = now;
+            rhythmAccuracy.miss++;
             combo = 0;
+            rhythmMultiplier = 1;
         }
 
         bestCombo = Math.max(bestCombo, combo);
@@ -412,6 +432,11 @@ document.addEventListener('DOMContentLoaded', () => {
             rhythmStartTime = 0;
             rhythmLastMissCheckedBeat = -1;
             rhythmLastHitBeat = -1;
+            rhythmMultiplier = 1;
+            rhythmAccuracy = { perfect: 0, good: 0, miss: 0 };
+            rhythmJudgeText = '';
+            rhythmJudgeColor = '#fff';
+            rhythmJudgeTime = 0;
         }
 
         cancelAnimationFrame(animationId);
@@ -540,36 +565,63 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function updateRhythm() {
-        const elapsed = performance.now() - rhythmStartTime;
+        const now = performance.now();
+        const elapsed = now - rhythmStartTime;
         const beatFloat = elapsed / rhythmBeatInterval;
         const beatPhase = beatFloat - Math.floor(beatFloat);
         const currentBeat = Math.floor(beatFloat);
 
         if (currentBeat > rhythmLastMissCheckedBeat) {
             const missedBeat = currentBeat - 1;
-            if (missedBeat >= 0 && rhythmLastHitBeat < missedBeat) combo = 0;
+            if (missedBeat >= 0 && rhythmLastHitBeat < missedBeat) {
+                combo = 0;
+                rhythmMultiplier = 1;
+                rhythmAccuracy.miss++;
+                rhythmJudgeText = 'MISS';
+                rhythmJudgeColor = '#fb7185';
+                rhythmJudgeTime = now;
+            }
             rhythmLastMissCheckedBeat = currentBeat;
         }
 
         const centerX = gameCanvas.width / 2;
         const centerY = gameCanvas.height / 2;
-        const baseRadius = Math.min(gameCanvas.width, gameCanvas.height) * 0.18;
-        const pulseRadius = baseRadius + beatPhase * baseRadius * 1.3;
+        const baseRadius = Math.min(gameCanvas.width, gameCanvas.height) * 0.16;
+        const judgementRadius = baseRadius * 2.6;
+        const pulseRadius = baseRadius + beatPhase * baseRadius * 1.9;
+        const pulseAlpha = Math.max(0.2, 1 - beatPhase * 0.85);
 
         ctx.fillStyle = '#020617';
         ctx.fillRect(0, 0, gameCanvas.width, gameCanvas.height);
 
-        ctx.strokeStyle = '#16e0bd';
-        ctx.lineWidth = 5;
+        // beat grid lines
+        ctx.strokeStyle = 'rgba(148, 163, 184, 0.15)';
+        ctx.lineWidth = 1;
+        for (let i = 0; i < 5; i++) {
+            const y = (gameCanvas.height / 5) * i;
+            ctx.beginPath();
+            ctx.moveTo(0, y);
+            ctx.lineTo(gameCanvas.width, y);
+            ctx.stroke();
+        }
+
+        ctx.strokeStyle = 'rgba(34, 211, 238, 0.9)';
+        ctx.lineWidth = 6;
         ctx.beginPath();
-        ctx.arc(centerX, centerY, baseRadius * 2.1, 0, Math.PI * 2);
+        ctx.arc(centerX, centerY, judgementRadius, 0, Math.PI * 2);
         ctx.stroke();
 
-        ctx.strokeStyle = 'rgba(120, 195, 251, 0.85)';
-        ctx.lineWidth = 8;
+        ctx.strokeStyle = `rgba(22, 224, 189, ${pulseAlpha})`;
+        ctx.lineWidth = 9;
         ctx.beginPath();
         ctx.arc(centerX, centerY, pulseRadius, 0, Math.PI * 2);
         ctx.stroke();
+
+        // center marker
+        ctx.fillStyle = '#0ea5e9';
+        ctx.beginPath();
+        ctx.arc(centerX, centerY, baseRadius * 0.52, 0, Math.PI * 2);
+        ctx.fill();
 
         ctx.fillStyle = '#f8fafc';
         ctx.font = '600 22px Outfit';
@@ -578,14 +630,32 @@ document.addEventListener('DOMContentLoaded', () => {
 
         drawScore();
         ctx.fillStyle = '#fff';
-        ctx.font = '18px Outfit';
+        ctx.font = '16px Outfit';
         ctx.textAlign = 'left';
         ctx.fillText(`콤보: ${combo}`, 20, 70);
-        ctx.fillText(`최고 콤보: ${bestCombo}`, 20, 98);
+        ctx.fillText(`배수: x${rhythmMultiplier}`, 20, 96);
+        ctx.fillText(`최고 콤보: ${bestCombo}`, 20, 122);
+
+        const totalHits = rhythmAccuracy.perfect + rhythmAccuracy.good + rhythmAccuracy.miss;
+        const accuracy = totalHits ? Math.round(((rhythmAccuracy.perfect + rhythmAccuracy.good * 0.6) / totalHits) * 100) : 100;
+        ctx.textAlign = 'right';
+        ctx.fillText(`정확도: ${accuracy}%`, gameCanvas.width - 20, 70);
+        ctx.fillText(`P:${rhythmAccuracy.perfect} G:${rhythmAccuracy.good} M:${rhythmAccuracy.miss}`, gameCanvas.width - 20, 96);
 
         const remain = Math.max(0, Math.ceil((rhythmDuration - elapsed) / 1000));
         ctx.textAlign = 'right';
         ctx.fillText(`남은 시간: ${remain}s`, gameCanvas.width - 20, 40);
+
+        if (rhythmJudgeText && now - rhythmJudgeTime < 520) {
+            const judgeProgress = (now - rhythmJudgeTime) / 520;
+            const yOffset = 40 * judgeProgress;
+            ctx.globalAlpha = 1 - judgeProgress;
+            ctx.fillStyle = rhythmJudgeColor;
+            ctx.textAlign = 'center';
+            ctx.font = '700 28px Outfit';
+            ctx.fillText(rhythmJudgeText, centerX, centerY - judgementRadius - 30 - yOffset);
+            ctx.globalAlpha = 1;
+        }
 
         if (elapsed >= rhythmDuration) {
             rhythmGameOver();
@@ -622,7 +692,9 @@ document.addEventListener('DOMContentLoaded', () => {
     function rhythmGameOver() {
         gameActive = false;
         gameTitle.innerText = '리듬 챌린지 종료';
-        gameInstr.innerText = `점수: ${score} | 최고 콤보: ${bestCombo}`;
+        const totalHits = rhythmAccuracy.perfect + rhythmAccuracy.good + rhythmAccuracy.miss;
+        const accuracy = totalHits ? Math.round(((rhythmAccuracy.perfect + rhythmAccuracy.good * 0.6) / totalHits) * 100) : 100;
+        gameInstr.innerText = `점수: ${score} | 최고 콤보: ${bestCombo} | 정확도: ${accuracy}%`;
         overlay.style.display = 'flex';
         updateMobileControlsVisibility();
     }

--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const overlay = document.getElementById('game-overlay');
     const gameTitle = document.getElementById('game-title');
     const gameCanvas = document.getElementById('game-canvas');
+    const gameInstr = document.getElementById('game-instr');
     const ctx = gameCanvas.getContext('2d');
 
     // Summarizer UI Elements
@@ -20,6 +21,11 @@ document.addEventListener('DOMContentLoaded', () => {
     // Theme Toggle & Easter Egg
     const themeToggle = document.getElementById('theme-toggle');
     let themeClickCount = 0;
+
+    // Mobile Controls
+    const mobileControls = document.getElementById('mobile-controls');
+    const controlButtons = document.querySelectorAll('.control-btn');
+    const isTouchDevice = window.matchMedia('(max-width: 1024px) and (pointer: coarse)').matches;
 
     const setTheme = (theme) => {
         document.documentElement.setAttribute('data-theme', theme);
@@ -41,13 +47,12 @@ document.addEventListener('DOMContentLoaded', () => {
             const newTheme = currentTheme === 'light' ? 'dark' : 'light';
             setTheme(newTheme);
 
-            // Easter Egg Logic
             themeClickCount++;
             if (themeClickCount === 30) {
                 if (messageModal) {
                     messageModal.style.display = 'block';
                 }
-                themeClickCount = 0; // Reset after trigger
+                themeClickCount = 0;
             }
         };
     }
@@ -63,7 +68,6 @@ document.addEventListener('DOMContentLoaded', () => {
         };
     }
 
-    // Close mobile menu when a link is clicked
     document.querySelectorAll('#nav-list li a').forEach(link => {
         link.onclick = () => {
             mobileMenu.classList.remove('is-active');
@@ -80,7 +84,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // Obfuscated API Key (Base64)
-    const _k = "QUl6YVN5RFBCNkxiN3Zpai10U0ZEQWNyeXR2UWVMX2gtcC1pNnVF";
+    const _k = 'QUl6YVN5RFBCNkxiN3Zpai10U0ZEQWNyeXR2UWVMX2gtcC1pNnVF';
 
     if (summarizeBtn) {
         summarizeBtn.onclick = async () => {
@@ -92,7 +96,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
 
-            // Use the stored key if input is empty
             if (!apiKey) {
                 apiKey = atob(_k);
             }
@@ -102,7 +105,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
 
-            // UI Reset
             summaryResult.style.display = 'none';
             loader.style.display = 'block';
             summarizeBtn.disabled = true;
@@ -145,11 +147,9 @@ document.addEventListener('DOMContentLoaded', () => {
     let animationId;
     let score = 0;
     let currentGame = '';
-
-    // Common Game State
     let frameCount = 0;
 
-    // Runner Game State (똥 피하기)
+    // Runner Game State
     const runnerPlayer = {
         x: 0,
         y: 0,
@@ -168,9 +168,37 @@ document.addEventListener('DOMContentLoaded', () => {
     let food = { x: 0, y: 0 };
     let dx = grid;
     let dy = 0;
-    let snakeSpeed = 10; // Increased from 7 to slow down (Frames per move)
+    let snakeSpeed = 10;
 
-    // Resize Canvas
+    // Rhythm Game State
+    const rhythmBeatInterval = 800;
+    const rhythmWindow = { perfect: 120, good: 220 };
+    const rhythmDuration = 30000;
+    let rhythmStartTime = 0;
+    let rhythmLastMissCheckedBeat = -1;
+    let rhythmLastHitBeat = -1;
+    let combo = 0;
+    let bestCombo = 0;
+
+    function updateMobileControlsVisibility() {
+        if (!mobileControls) return;
+
+        const shouldShowControls = Boolean(currentGame) && isTouchDevice;
+        mobileControls.style.display = shouldShowControls ? 'grid' : 'none';
+
+        const visibleControlsByGame = {
+            'galaxy-runner': new Set(['left', 'right']),
+            snake: new Set(['left', 'up', 'down', 'right']),
+            rhythm: new Set(['action'])
+        };
+        const visibleControls = visibleControlsByGame[currentGame] || new Set();
+
+        controlButtons.forEach(btn => {
+            btn.classList.remove('active');
+            btn.style.visibility = visibleControls.has(btn.dataset.control) ? 'visible' : 'hidden';
+        });
+    }
+
     function resizeCanvas() {
         const container = document.getElementById('game-container');
         let width = container.clientWidth;
@@ -184,55 +212,144 @@ document.addEventListener('DOMContentLoaded', () => {
         gameCanvas.width = width;
         gameCanvas.height = height;
 
-        // Initial state for Runner
         runnerPlayer.y = gameCanvas.height - 50;
         runnerPlayer.x = gameCanvas.width / 2 - runnerPlayer.width / 2;
     }
 
-    // Modal Logic
+    function getGameText(type) {
+        if (type === 'galaxy-runner') return { title: '불규칙한 똥 피하기', instr: '방향키/좌우 버튼으로 이동하세요.' };
+        if (type === 'snake') return { title: '네온 스네이크', instr: '방향키/방향 버튼으로 뱀을 조종하세요.' };
+        return { title: '클릭 리듬 챌린지', instr: '비트가 원에 겹칠 때 클릭/스페이스/TAP!' };
+    }
+
     playButtons.forEach(btn => {
         btn.onclick = () => {
             currentGame = btn.getAttribute('data-game');
             modal.style.display = 'block';
             resizeCanvas();
-            const title = currentGame === 'galaxy-runner' ? '불규칙한 똥 피하기' : '네온 스네이크';
+            const { title } = getGameText(currentGame);
             resetGame(title);
+            updateMobileControlsVisibility();
         };
     });
 
     closeBtn.onclick = () => {
         modal.style.display = 'none';
         stopGame();
+        currentGame = '';
+        updateMobileControlsVisibility();
     };
 
     window.onclick = (event) => {
         if (event.target == modal) {
             modal.style.display = 'none';
             stopGame();
+            currentGame = '';
+            updateMobileControlsVisibility();
         }
     };
 
-    // Input Handling
     const keys = {};
+
+    function setSnakeDirection(direction) {
+        if (direction === 'left' && dx === 0) { dx = -grid; dy = 0; }
+        if (direction === 'up' && dy === 0) { dy = -grid; dx = 0; }
+        if (direction === 'right' && dx === 0) { dx = grid; dy = 0; }
+        if (direction === 'down' && dy === 0) { dy = grid; dx = 0; }
+    }
+
+    function rhythmTap() {
+        if (!gameActive || currentGame !== 'rhythm') return;
+        const now = performance.now();
+        const elapsed = now - rhythmStartTime;
+        const beat = Math.round(elapsed / rhythmBeatInterval);
+        const beatTime = beat * rhythmBeatInterval;
+        const diff = Math.abs(elapsed - beatTime);
+
+        if (beat === rhythmLastHitBeat) return;
+
+        if (diff <= rhythmWindow.perfect) {
+            score += 3;
+            combo += 1;
+            rhythmLastHitBeat = beat;
+        } else if (diff <= rhythmWindow.good) {
+            score += 1;
+            combo += 1;
+            rhythmLastHitBeat = beat;
+        } else {
+            combo = 0;
+        }
+
+        bestCombo = Math.max(bestCombo, combo);
+    }
+
+    function pressControl(control) {
+        if (!gameActive) return;
+        if (currentGame === 'snake') {
+            setSnakeDirection(control);
+            return;
+        }
+        if (currentGame === 'galaxy-runner') {
+            if (control === 'left') keys.ArrowLeft = true;
+            if (control === 'right') keys.ArrowRight = true;
+            return;
+        }
+        if (currentGame === 'rhythm' && control === 'action') {
+            rhythmTap();
+        }
+    }
+
+    function releaseControl(control) {
+        if (currentGame !== 'galaxy-runner') return;
+        if (control === 'left') keys.ArrowLeft = false;
+        if (control === 'right') keys.ArrowRight = false;
+    }
+
+    controlButtons.forEach(button => {
+        const control = button.dataset.control;
+        const activate = (event) => {
+            event.preventDefault();
+            button.classList.add('active');
+            pressControl(control);
+        };
+        const deactivate = () => {
+            button.classList.remove('active');
+            releaseControl(control);
+        };
+
+        button.addEventListener('touchstart', activate, { passive: false });
+        button.addEventListener('touchend', deactivate);
+        button.addEventListener('touchcancel', deactivate);
+        button.addEventListener('mousedown', activate);
+        button.addEventListener('mouseup', deactivate);
+        button.addEventListener('mouseleave', deactivate);
+    });
+
     window.addEventListener('keydown', e => {
         keys[e.code] = true;
-        // Prevent default scrolling for game keys
+
         if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Space'].includes(e.code)) {
             e.preventDefault();
         }
 
-        // Snake specific direction change (prevent 180 degree turns)
         if (currentGame === 'snake') {
-            if (e.code === 'ArrowLeft' && dx === 0) { dx = -grid; dy = 0; }
-            if (e.code === 'ArrowUp' && dy === 0) { dy = -grid; dx = 0; }
-            if (e.code === 'ArrowRight' && dx === 0) { dx = grid; dy = 0; }
-            if (e.code === 'ArrowDown' && dy === 0) { dy = grid; dx = 0; }
+            if (e.code === 'ArrowLeft') setSnakeDirection('left');
+            if (e.code === 'ArrowUp') setSnakeDirection('up');
+            if (e.code === 'ArrowRight') setSnakeDirection('right');
+            if (e.code === 'ArrowDown') setSnakeDirection('down');
+        }
+
+        if (currentGame === 'rhythm' && (e.code === 'Space' || e.code === 'Enter')) {
+            rhythmTap();
         }
     });
-    window.addEventListener('keyup', e => keys[e.code] = false);
 
-    // Mobile Input
+    window.addEventListener('keyup', e => {
+        keys[e.code] = false;
+    });
+
     gameCanvas.addEventListener('touchstart', e => {
+        e.preventDefault();
         const touchX = e.touches[0].clientX;
         const touchY = e.touches[0].clientY;
         const rect = gameCanvas.getBoundingClientRect();
@@ -243,26 +360,29 @@ document.addEventListener('DOMContentLoaded', () => {
             if (canvasX < gameCanvas.width / 2) runnerPlayer.x -= runnerPlayer.speed * 3;
             else runnerPlayer.x += runnerPlayer.speed * 3;
         } else if (currentGame === 'snake') {
-            // Simple 4-way tap logic for snake
             const centerX = gameCanvas.width / 2;
             const centerY = gameCanvas.height / 2;
             if (Math.abs(canvasX - centerX) > Math.abs(canvasY - centerY)) {
-                if (canvasX < centerX && dx === 0) { dx = -grid; dy = 0; }
-                else if (canvasX > centerX && dx === 0) { dx = grid; dy = 0; }
+                if (canvasX < centerX) setSnakeDirection('left');
+                else setSnakeDirection('right');
+            } else if (canvasY < centerY) {
+                setSnakeDirection('up');
             } else {
-                if (canvasY < centerY && dy === 0) { dy = -grid; dx = 0; }
-                else if (canvasY > centerY && dy === 0) { dy = grid; dx = 0; }
+                setSnakeDirection('down');
             }
+        } else if (currentGame === 'rhythm') {
+            rhythmTap();
         }
-    });
+    }, { passive: false });
 
-    // Game Functions
     function resetGame(title) {
         gameActive = false;
         score = 0;
+        combo = 0;
+        bestCombo = 0;
         frameCount = 0;
         gameTitle.innerText = title;
-        document.getElementById('game-instr').innerText = currentGame === 'galaxy-runner' ? '방향키 또는 터치로 이동하세요.' : '방향키로 뱀을 조종하세요.';
+        gameInstr.innerText = getGameText(currentGame).instr;
         overlay.style.display = 'flex';
 
         if (currentGame === 'galaxy-runner') {
@@ -279,6 +399,10 @@ document.addEventListener('DOMContentLoaded', () => {
             dy = 0;
             snakeSpeed = 10;
             spawnFood();
+        } else if (currentGame === 'rhythm') {
+            rhythmStartTime = 0;
+            rhythmLastMissCheckedBeat = -1;
+            rhythmLastHitBeat = -1;
         }
 
         cancelAnimationFrame(animationId);
@@ -287,6 +411,11 @@ document.addEventListener('DOMContentLoaded', () => {
     function startGame() {
         overlay.style.display = 'none';
         gameActive = true;
+        if (currentGame === 'rhythm') {
+            rhythmStartTime = performance.now();
+            rhythmLastMissCheckedBeat = -1;
+            rhythmLastHitBeat = -1;
+        }
         gameLoop();
     }
 
@@ -295,19 +424,17 @@ document.addEventListener('DOMContentLoaded', () => {
         cancelAnimationFrame(animationId);
     }
 
-    // Runner Specific Functions
     function spawnObstacle() {
         const width = Math.random() * 60 + 20;
         obstacles.push({
             x: Math.random() * (gameCanvas.width - width),
             y: -50,
-            width: width,
-            height: width * 0.8, // Irregular height
-            color: '#795548' // Brown for "Poo"
+            width,
+            height: width * 0.8,
+            color: '#795548'
         });
     }
 
-    // Snake Specific Functions
     function spawnFood() {
         food.x = Math.floor(Math.random() * (gameCanvas.width / grid)) * grid;
         food.y = Math.floor(Math.random() * (gameCanvas.height / grid)) * grid;
@@ -323,32 +450,30 @@ document.addEventListener('DOMContentLoaded', () => {
             updateRunner();
         } else if (currentGame === 'snake') {
             updateSnake();
+        } else if (currentGame === 'rhythm') {
+            updateRhythm();
         }
 
         animationId = requestAnimationFrame(gameLoop);
     }
 
     function updateRunner() {
-        // Move Player
-        if (keys['ArrowLeft'] || keys['KeyA']) runnerPlayer.x -= runnerPlayer.speed;
-        if (keys['ArrowRight'] || keys['KeyD']) runnerPlayer.x += runnerPlayer.speed;
+        if (keys.ArrowLeft || keys.KeyA) runnerPlayer.x -= runnerPlayer.speed;
+        if (keys.ArrowRight || keys.KeyD) runnerPlayer.x += runnerPlayer.speed;
 
         if (runnerPlayer.x < 0) runnerPlayer.x = 0;
         if (runnerPlayer.x + runnerPlayer.width > gameCanvas.width) runnerPlayer.x = gameCanvas.width - runnerPlayer.width;
 
-        // Draw Player
         ctx.fillStyle = runnerPlayer.color;
         ctx.beginPath();
         ctx.roundRect(runnerPlayer.x, runnerPlayer.y, runnerPlayer.width, runnerPlayer.height, 5);
         ctx.fill();
 
-        // Handle Obstacles
         if (frameCount % obstacleFrequency === 0) spawnObstacle();
 
         obstacles.forEach((obs, index) => {
             obs.y += obstacleSpeed + (score / 15);
 
-            // Draw "Poo" (Irregular circle)
             ctx.fillStyle = obs.color;
             ctx.beginPath();
             ctx.ellipse(obs.x + obs.width / 2, obs.y + obs.height / 2, obs.width / 2, obs.height / 2, 0, 0, Math.PI * 2);
@@ -369,12 +494,10 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
 
-        // Draw Score
         drawScore();
     }
 
     function updateSnake() {
-        // Slow down snake updates
         if (frameCount % snakeSpeed !== 0) {
             drawSnake();
             drawScore();
@@ -383,23 +506,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const head = { x: snake[0].x + dx, y: snake[0].y + dy };
 
-        // Wall Collision
         if (head.x < 0 || head.x >= gameCanvas.width || head.y < 0 || head.y >= gameCanvas.height) {
             return gameOver();
         }
 
-        // Self Collision
         for (let i = 0; i < snake.length; i++) {
             if (head.x === snake[i].x && head.y === snake[i].y) return gameOver();
         }
 
         snake.unshift(head);
 
-        // Food Collision
         if (head.x === food.x && head.y === food.y) {
             score++;
             spawnFood();
-            // Slower speedup: every 7 points, and min speed is 4
             if (score % 7 === 0 && snakeSpeed > 4) snakeSpeed--;
         } else {
             snake.pop();
@@ -409,8 +528,60 @@ document.addEventListener('DOMContentLoaded', () => {
         drawScore();
     }
 
+    function updateRhythm() {
+        const elapsed = performance.now() - rhythmStartTime;
+        const beatFloat = elapsed / rhythmBeatInterval;
+        const beatPhase = beatFloat - Math.floor(beatFloat);
+        const currentBeat = Math.floor(beatFloat);
+
+        if (currentBeat > rhythmLastMissCheckedBeat) {
+            const missedBeat = currentBeat - 1;
+            if (missedBeat >= 0 && rhythmLastHitBeat < missedBeat) combo = 0;
+            rhythmLastMissCheckedBeat = currentBeat;
+        }
+
+        const centerX = gameCanvas.width / 2;
+        const centerY = gameCanvas.height / 2;
+        const baseRadius = Math.min(gameCanvas.width, gameCanvas.height) * 0.18;
+        const pulseRadius = baseRadius + beatPhase * baseRadius * 1.3;
+
+        ctx.fillStyle = '#020617';
+        ctx.fillRect(0, 0, gameCanvas.width, gameCanvas.height);
+
+        ctx.strokeStyle = '#16e0bd';
+        ctx.lineWidth = 5;
+        ctx.beginPath();
+        ctx.arc(centerX, centerY, baseRadius * 2.1, 0, Math.PI * 2);
+        ctx.stroke();
+
+        ctx.strokeStyle = 'rgba(120, 195, 251, 0.85)';
+        ctx.lineWidth = 8;
+        ctx.beginPath();
+        ctx.arc(centerX, centerY, pulseRadius, 0, Math.PI * 2);
+        ctx.stroke();
+
+        ctx.fillStyle = '#f8fafc';
+        ctx.font = '600 22px Outfit';
+        ctx.textAlign = 'center';
+        ctx.fillText('TAP!', centerX, centerY + 8);
+
+        drawScore();
+        ctx.fillStyle = '#fff';
+        ctx.font = '18px Outfit';
+        ctx.textAlign = 'left';
+        ctx.fillText(`콤보: ${combo}`, 20, 70);
+        ctx.fillText(`최고 콤보: ${bestCombo}`, 20, 98);
+
+        const remain = Math.max(0, Math.ceil((rhythmDuration - elapsed) / 1000));
+        ctx.textAlign = 'right';
+        ctx.fillText(`남은 시간: ${remain}s`, gameCanvas.width - 20, 40);
+
+        if (elapsed >= rhythmDuration) {
+            rhythmGameOver();
+        }
+    }
+
     function drawSnake() {
-        // Draw Food (Neon Pulse)
         ctx.fillStyle = '#f43f5e';
         ctx.shadowBlur = 15;
         ctx.shadowColor = '#f43f5e';
@@ -419,7 +590,6 @@ document.addEventListener('DOMContentLoaded', () => {
         ctx.fill();
         ctx.shadowBlur = 0;
 
-        // Draw Snake
         snake.forEach((part, index) => {
             ctx.fillStyle = index === 0 ? '#10b981' : '#34d399';
             ctx.shadowBlur = index === 0 ? 10 : 0;
@@ -434,31 +604,44 @@ document.addEventListener('DOMContentLoaded', () => {
     function drawScore() {
         ctx.fillStyle = '#fff';
         ctx.font = '20px Outfit';
+        ctx.textAlign = 'left';
         ctx.fillText(`점수: ${score}`, 20, 40);
+    }
+
+    function rhythmGameOver() {
+        gameActive = false;
+        gameTitle.innerText = '리듬 챌린지 종료';
+        gameInstr.innerText = `점수: ${score} | 최고 콤보: ${bestCombo}`;
+        overlay.style.display = 'flex';
     }
 
     function gameOver() {
         gameActive = false;
         gameTitle.innerText = '게임 오버';
-        document.getElementById('game-instr').innerText = `최종 점수: ${score}`;
+        gameInstr.innerText = `최종 점수: ${score}`;
         overlay.style.display = 'flex';
-        // Reset state for next try
         setTimeout(() => {
             if (overlay.style.display === 'flex') {
-                const title = currentGame === 'galaxy-runner' ? '불규칙한 똥 피하기' : '네온 스네이크';
+                const { title } = getGameText(currentGame);
                 gameTitle.innerText = title;
-                document.getElementById('game-instr').innerText = currentGame === 'galaxy-runner' ? '다시 도전하시겠습니까?' : '다시 도전하시겠습니까?';
+                gameInstr.innerText = '다시 도전하시겠습니까?';
             }
         }, 2000);
     }
 
     startBtn.onclick = () => {
-        const title = currentGame === 'galaxy-runner' ? '불규칙한 똥 피하기' : '네온 스네이크';
+        const { title } = getGameText(currentGame);
         resetGame(title);
         startGame();
     };
 
-    // Intersection Observer
+    window.addEventListener('resize', () => {
+        if (modal && modal.style.display === 'block' && currentGame) {
+            resizeCanvas();
+        }
+        updateMobileControlsVisibility();
+    });
+
     const observer = new IntersectionObserver((entries) => {
         entries.forEach(entry => {
             if (entry.isIntersecting) {
@@ -468,6 +651,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }, { threshold: 0.1 });
 
     document.querySelectorAll('.reveal-text').forEach(el => {
+        observer.observe(el);
         el.style.opacity = '1';
         el.style.transform = 'translateY(0)';
     });

--- a/style.css
+++ b/style.css
@@ -337,6 +337,13 @@ nav ul li a:hover::after {
     width: 100%;
 }
 
+.rhythm-preview {
+    background:
+        radial-gradient(circle at 20% 20%, rgba(120, 195, 251, 0.9), transparent 45%),
+        radial-gradient(circle at 80% 70%, rgba(22, 224, 189, 0.8), transparent 42%),
+        linear-gradient(120deg, #111827, #1f2937 55%, #0f172a);
+}
+
 .project-info {
     padding: 1.5rem;
 }
@@ -604,6 +611,34 @@ footer {
     display: block;
 }
 
+.mobile-controls {
+    position: absolute;
+    bottom: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: calc(100% - 24px);
+    display: none;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 0.5rem;
+    z-index: 12;
+}
+
+.control-btn {
+    border: 1px solid var(--glass-border);
+    border-radius: 14px;
+    background: rgba(15, 23, 42, 0.6);
+    color: #fff;
+    font-weight: 700;
+    min-height: 48px;
+    cursor: pointer;
+    touch-action: manipulation;
+}
+
+.control-btn.active {
+    background: rgba(22, 224, 189, 0.8);
+    color: #042f2e;
+}
+
 .overlay {
     position: absolute;
     top: 0;
@@ -690,6 +725,13 @@ footer {
     .menu-toggle.is-active .bar:nth-child(3) {
         transform: translateY(-8px) rotate(-45deg);
     }
+
+    .modal-content {
+        width: 95%;
+        height: 85vh;
+        margin: 3vh auto;
+    }
+
 }
 
 .menu-toggle {


### PR DESCRIPTION
### Motivation
- Introduce a new rhythm mini-game and provide touch-first controls so games are playable on mobile devices. 
- Improve the in-modal game UX by exposing game instructions dynamically and showing appropriate on-screen controls per game. 
- Clean up and refactor input handling and small UI bits for consistency and better responsiveness.

### Description
- Added a new project card for the rhythm game in `index.html` and a `#mobile-controls` control bar inside the game modal to expose directional/action buttons for touch devices. 
- Implemented a full rhythm game state and loop in `main.js` (`rhythmBeatInterval`, `rhythmTap`, `updateRhythm`, scoring/combo logic, `rhythmGameOver`) plus touch/mouse handlers and game-specific control mapping (`pressControl`, `releaseControl`, `setSnakeDirection`, `getGameText`, `updateMobileControlsVisibility`).
- Refactored input handling to unify keyboard/touch interactions, added safe touch handling (`{ passive: false }`), made game instruction text dynamic via `gameInstr`, and adjusted canvas resizing and modal lifecycle to update controls accordingly. 
- Added related styles in `style.css` including `.rhythm-preview`, `.mobile-controls`, `.control-btn`, and modal sizing tweaks, and minor JS/HTML cleanups (string quoting consistency, intersection observer usage, small rendering fixes).

### Testing
- Ran static checks: `eslint` and `stylelint` on modified files, and both checks completed without errors. 
- Performed a local build with `npm run build` which succeeded and produced the expected bundle. 
- No automated unit tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a51c535c3483268a1277085d18b5e4)